### PR TITLE
Fixed a NullException Bug

### DIFF
--- a/jmd-core/src/main/java/net/contra/jmd/transformers/smokescreen/SmokeScreenTransformer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/smokescreen/SmokeScreenTransformer.java
@@ -33,6 +33,9 @@ public class SmokeScreenTransformer implements Transformer {
             for (Method m : cg.getMethods()) {
                 MethodGen mg = new MethodGen(m, cg.getClassName(), cg.getConstantPool());
                 InstructionList list = mg.getInstructionList();
+                if (list == null) {
+                    return;
+                }
                 InstructionHandle[] handles = list.getInstructionHandles();
                 for (int x = 0; x < handles.length; x++) {
                     if (x + 3 < handles.length) {
@@ -74,6 +77,9 @@ public class SmokeScreenTransformer implements Transformer {
                 int key = 0;
                 MethodGen mg = new MethodGen(m, cg.getClassName(), cg.getConstantPool());
                 InstructionList list = mg.getInstructionList();
+                if (list == null) {
+                    return;
+                }
                 InstructionHandle[] handles = list.getInstructionHandles();
                 for (int x = 0; x < handles.length; x++) {
                     if (x + 3 < handles.length) {


### PR DESCRIPTION
A null exception bug may occur if the list is null.

To fix this, return from function if list is null.

Please add this. Thanks