### PR TITLE
Allatori close

### DIFF
--- a/jmd-cli/src/main/java/net/contra/jmd/Deobfuscator.java
+++ b/jmd-cli/src/main/java/net/contra/jmd/Deobfuscator.java
@@ -82,5 +82,6 @@ public class Deobfuscator {
         Scanner in = new Scanner(System.in);
         logger.message("Press any key to exit...");
         in.nextLine();
+        in.close();
     }
 }

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/allatori/AllatoriTransformer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/allatori/AllatoriTransformer.java
@@ -46,6 +46,7 @@ public class AllatoriTransformer implements Transformer {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     private boolean isStringClass(ClassGen cg) {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/dasho/DashOTransformer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/dasho/DashOTransformer.java
@@ -43,6 +43,7 @@ public class DashOTransformer implements Transformer {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     public static String decrypt(String input) {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/generic/ForeignCallRemover.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/generic/ForeignCallRemover.java
@@ -46,6 +46,7 @@ public class ForeignCallRemover {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     public boolean isAuthClass(ClassGen cg) {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/generic/GenericStringDeobfuscator.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/generic/GenericStringDeobfuscator.java
@@ -47,6 +47,7 @@ public class GenericStringDeobfuscator {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     public void replaceStrings() {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/generic/Renamer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/generic/Renamer.java
@@ -44,6 +44,7 @@ public class Renamer {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     public void renameClasses() {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/generic/StackFixer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/generic/StackFixer.java
@@ -44,6 +44,7 @@ public class StackFixer {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     public void fixStack() {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/generic/StringFixer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/generic/StringFixer.java
@@ -43,6 +43,7 @@ public class StringFixer {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     public void removeBASA() {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/generic/StringScanner.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/generic/StringScanner.java
@@ -40,6 +40,7 @@ public class StringScanner {
                 NonClassEntries.add(entry, jf.getInputStream(entry));
             }
         }
+        jf.close();
     }
 
     public void searchConstantPool() {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/jshrink/JShrinkTransformer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/jshrink/JShrinkTransformer.java
@@ -50,6 +50,7 @@ public class JShrinkTransformer implements Transformer {
         if (LoaderClass == null) {
             logger.error("Loader class not found! Class not using JShrink");
         }
+        jf.close();
     }
 
     public boolean isLoader(ClassGen cg) {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/smokescreen/SmokeScreenTransformer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/smokescreen/SmokeScreenTransformer.java
@@ -117,6 +117,7 @@ public class SmokeScreenTransformer implements Transformer {
             }
         }
         logger.debug("Classes loaded from JAR");
+        jf.close();
     }
 
     public static String decrypt(String encrypted, int myKey) {

--- a/jmd-core/src/main/java/net/contra/jmd/transformers/zkm/ZKMTransformer.java
+++ b/jmd-core/src/main/java/net/contra/jmd/transformers/zkm/ZKMTransformer.java
@@ -45,6 +45,7 @@ public class ZKMTransformer implements Transformer {
             }
         }
         logger.debug("Classes loaded from JAR");
+        jf.close();
     }
 
     public static boolean typeA(ClassGen cg) {


### PR DESCRIPTION
These files were not closed properly after the end of usage, which is a waste of resources. Therefore, a `close()` statement should be added to fix the problem.