### PR TITLE
Must press enter to exit

### DIFF
--- a/jmd-cli/src/main/java/net/contra/jmd/Deobfuscator.java
+++ b/jmd-cli/src/main/java/net/contra/jmd/Deobfuscator.java
@@ -80,7 +80,8 @@ public class Deobfuscator {
                     "\n ForeignCallRemover, GenericStringDeobfuscator, StackFixer, StringFixer, Renamer, and StringReplacer (not case sensitive)");
         }
         Scanner in = new Scanner(System.in);
-        logger.message("Press any key to exit...");
+        logger.message("Press <Enter> key to exit...");
         in.nextLine();
+        in.close();
     }
 }


### PR DESCRIPTION
By definition, `.newline()` must be closed with a newline (<Enter>) key. Therefore, it should be specified to avoid any confusion.